### PR TITLE
Wii classic controller and nunchuk support

### DIFF
--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
@@ -6,39 +6,60 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
     WPAD_ScanPads();
 
     this->buttonMasks = WPAD_ButtonsHeld(0);
-
-    this->stateUp     = (this->buttonMasks & WPAD_BUTTON_RIGHT) != 0;
-    this->stateDown   = (this->buttonMasks & WPAD_BUTTON_LEFT) != 0;
-    this->stateLeft   = (this->buttonMasks & WPAD_BUTTON_UP) != 0;
-    this->stateRight  = (this->buttonMasks & WPAD_BUTTON_DOWN) != 0;
-    this->stateA      = (this->buttonMasks & WPAD_BUTTON_2) != 0;
-    this->stateB      = (this->buttonMasks & WPAD_BUTTON_1) != 0;
-    this->stateC      = (this->buttonMasks & 0) != 0;
-    this->stateX      = (this->buttonMasks & WPAD_BUTTON_A) != 0;
-    this->stateY      = (this->buttonMasks & WPAD_BUTTON_B) != 0;
-    this->stateZ      = (this->buttonMasks & 0) != 0;
-    this->stateStart  = (this->buttonMasks & WPAD_BUTTON_PLUS) != 0;
-    this->stateSelect = (this->buttonMasks & WPAD_BUTTON_MINUS) != 0;
-
-    WPADData *data = WPAD_Data(0);
-    if (data && data->exp.type == WPAD_EXP_CLASSIC)
-    {
-        this->stateUp     |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_UP) != 0;
-        this->stateDown   |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_DOWN) != 0;
-        this->stateLeft   |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_LEFT) != 0;
-        this->stateRight  |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_RIGHT) != 0;
-        this->stateA      |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_B) != 0;
-        this->stateB      |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_A) != 0;
-        this->stateC      |= (this->buttonMasks & 0) != 0;
-        this->stateX      |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_Y) != 0;
-        this->stateY      |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_X) != 0;
-        this->stateZ      |= (this->buttonMasks & 0) != 0;
-        this->stateStart  |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_PLUS) != 0;
-        this->stateSelect |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_MINUS) != 0;	
-        this->stateUp |= (data->exp.classic.ljs.pos.y > data->exp.classic.ljs.center.y + 5) ? 1 : 0;
-        this->stateDown |= (data->exp.classic.ljs.pos.y < data->exp.classic.ljs.center.y - 5) ? 1 : 0;
-        this->stateLeft |= (data->exp.classic.ljs.pos.x < data->exp.classic.ljs.center.x - 5) ? 1 : 0;
-        this->stateRight |= (data->exp.classic.ljs.pos.x > data->exp.classic.ljs.center.x + 5) ? 1 : 0;
+    int type = data->exp.type;
+    switch (type) {
+        case WPAD_EXP_NONE:
+            this->stateUp     = (this->buttonMasks & WPAD_BUTTON_RIGHT) != 0;
+            this->stateDown   = (this->buttonMasks & WPAD_BUTTON_LEFT) != 0;
+            this->stateLeft   = (this->buttonMasks & WPAD_BUTTON_UP) != 0;
+            this->stateRight  = (this->buttonMasks & WPAD_BUTTON_DOWN) != 0;
+            this->stateA      = (this->buttonMasks & WPAD_BUTTON_1) != 0;
+            this->stateB      = (this->buttonMasks & WPAD_BUTTON_2) != 0;
+            this->stateC      = (this->buttonMasks & 0) != 0;
+            this->stateX      = (this->buttonMasks & WPAD_BUTTON_A) != 0;
+            this->stateY      = (this->buttonMasks & WPAD_BUTTON_B) != 0;
+            this->stateZ      = (this->buttonMasks & 0) != 0;
+            this->stateStart  = (this->buttonMasks & WPAD_BUTTON_PLUS) != 0;
+            this->stateSelect = (this->buttonMasks & WPAD_BUTTON_MINUS) != 0;
+            break;
+        case WPAD_EXP_NUNCHUK:
+            this->stateUp       = (this->buttonMasks & WPAD_BUTTON_UP) != 0;
+            this->stateDown     = (this->buttonMasks & WPAD_BUTTON_DOWN) != 0;
+            this->stateLeft     = (this->buttonMasks & WPAD_BUTTON_LEFT) != 0;
+            this->stateRight    = (this->buttonMasks & WPAD_BUTTON_RIGHT) != 0;
+            this->stateA        = (this->buttonMasks & WPAD_BUTTON_B) != 0;
+            this->stateB        = (this->buttonMasks & WPAD_BUTTON_A) != 0;
+            this->stateC        = (this->buttonMasks & 0) != 0;
+            this->stateX        = (this->buttonMasks & WPAD_NUNCHUK_BUTTON_C) != 0;
+            this->stateY        = (this->buttonMasks & WPAD_NUNCHUK_BUTTON_Z) != 0;
+            this->stateZ        = (this->buttonMasks & 0) != 0;
+            this->stateStart    = (this->buttonMasks & WPAD_BUTTON_PLUS) != 0;
+            this->stateSelect   = (this->buttonMasks & WPAD_BUTTON_MINUS) != 0;
+            this->stateUp       |= (data->exp.nunchuk.js.pos.y > data->exp.nunchuk.js.center.y + 5) ? 1 : 0;
+            this->stateDown     |= (data->exp.nunchuk.js.pos.y < data->exp.nunchuk.js.center.y - 5) ? 1 : 0;
+            this->stateLeft     |= (data->exp.nunchuk.js.pos.x < data->exp.nunchuk.js.center.x - 5) ? 1 : 0;
+            this->stateRight    |= (data->exp.nunchuk.js.pos.x > data->exp.nunchuk.js.center.x + 5) ? 1 : 0;
+            break;
+        case WPAD_EXP_CLASSIC:
+            this->stateUp       = (this->buttonMasks & WPAD_CLASSIC_BUTTON_UP) != 0;
+            this->stateDown     = (this->buttonMasks & WPAD_CLASSIC_BUTTON_DOWN) != 0;
+            this->stateLeft     = (this->buttonMasks & WPAD_CLASSIC_BUTTON_LEFT) != 0;
+            this->stateRight    = (this->buttonMasks & WPAD_CLASSIC_BUTTON_RIGHT) != 0;
+            this->stateA        = (this->buttonMasks & WPAD_CLASSIC_BUTTON_B) != 0;
+            this->stateB        = (this->buttonMasks & WPAD_CLASSIC_BUTTON_A) != 0;
+            this->stateC        = (this->buttonMasks & 0) != 0;
+            this->stateX        = (this->buttonMasks & WPAD_CLASSIC_BUTTON_Y) != 0;
+            this->stateY        = (this->buttonMasks & WPAD_CLASSIC_BUTTON_X) != 0;
+            this->stateZ        = (this->buttonMasks & 0) != 0;
+            this->stateStart    = (this->buttonMasks & WPAD_CLASSIC_BUTTON_PLUS) != 0;
+            this->stateSelect   = (this->buttonMasks & WPAD_CLASSIC_BUTTON_MINUS) != 0;
+            this->stateUp       |= (data->exp.classic.ljs.pos.y > data->exp.classic.ljs.center.y + 5) ? 1 : 0;
+            this->stateDown     |= (data->exp.classic.ljs.pos.y < data->exp.classic.ljs.center.y - 5) ? 1 : 0;
+            this->stateLeft     |= (data->exp.classic.ljs.pos.x < data->exp.classic.ljs.center.x - 5) ? 1 : 0;
+            this->stateRight    |= (data->exp.classic.ljs.pos.x > data->exp.classic.ljs.center.x + 5) ? 1 : 0;
+            break;
+        default:
+            break;
     }
     // Update both
     this->ProcessInput(CONT_ANY);

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
@@ -20,6 +20,22 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
     this->stateStart  = (this->buttonMasks & WPAD_BUTTON_PLUS) != 0;
     this->stateSelect = (this->buttonMasks & WPAD_BUTTON_MINUS) != 0;
 
+    WPADData *data = WPAD_Data(0);
+    if (data && data->exp.type == WPAD_EXP_CLASSIC)
+    {
+        this->stateUp     |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_UP) != 0;
+        this->stateDown   |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_DOWN) != 0;
+        this->stateLeft   |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_LEFT) != 0;
+        this->stateRight  |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_RIGHT) != 0;
+        this->stateA      |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_B) != 0;
+        this->stateB      |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_A) != 0;
+        this->stateC      |= (this->buttonMasks & 0) != 0;
+        this->stateX      |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_Y) != 0;
+        this->stateY      |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_X) != 0;
+        this->stateZ      |= (this->buttonMasks & 0) != 0;
+        this->stateStart  |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_PLUS) != 0;
+        this->stateSelect |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_MINUS) != 0;	
+    }
     // Update both
     this->ProcessInput(CONT_ANY);
     this->ProcessInput(CONT_P1);

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
@@ -8,8 +8,9 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
     this->buttonMasks = WPAD_ButtonsHeld(0);
     WPADData *data = WPAD_Data(0);
     int type = data->exp.type;
-    switch (type) {
-        case WPAD_EXP_NONE:
+    switch (type) 
+    {
+        case WPAD_EXP_NONE: default:
             this->stateUp     = (this->buttonMasks & WPAD_BUTTON_RIGHT) != 0;
             this->stateDown   = (this->buttonMasks & WPAD_BUTTON_LEFT) != 0;
             this->stateLeft   = (this->buttonMasks & WPAD_BUTTON_UP) != 0;
@@ -58,8 +59,6 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
             this->stateDown     |= (data->exp.classic.ljs.pos.y < data->exp.classic.ljs.center.y - 5) ? 1 : 0;
             this->stateLeft     |= (data->exp.classic.ljs.pos.x < data->exp.classic.ljs.center.x - 5) ? 1 : 0;
             this->stateRight    |= (data->exp.classic.ljs.pos.x > data->exp.classic.ljs.center.x + 5) ? 1 : 0;
-            break;
-        default:
             break;
     }
     // Update both

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
@@ -6,6 +6,7 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
     WPAD_ScanPads();
 
     this->buttonMasks = WPAD_ButtonsHeld(0);
+    WPADData *data = WPAD_Data(0);
     int type = data->exp.type;
     switch (type) {
         case WPAD_EXP_NONE:

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
@@ -18,8 +18,8 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
             this->stateA      = (this->buttonMasks & WPAD_BUTTON_1) != 0;
             this->stateB      = (this->buttonMasks & WPAD_BUTTON_2) != 0;
             this->stateC      = (this->buttonMasks & 0) != 0;
-            this->stateX      = (this->buttonMasks & WPAD_BUTTON_A) != 0;
-            this->stateY      = (this->buttonMasks & WPAD_BUTTON_B) != 0;
+            this->stateX      = (this->buttonMasks & WPAD_BUTTON_B) != 0;
+            this->stateY      = (this->buttonMasks & WPAD_BUTTON_A) != 0;
             this->stateZ      = (this->buttonMasks & 0) != 0;
             this->stateStart  = (this->buttonMasks & WPAD_BUTTON_PLUS) != 0;
             this->stateSelect = (this->buttonMasks & WPAD_BUTTON_MINUS) != 0;
@@ -37,10 +37,10 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
             this->stateZ        = (this->buttonMasks & 0) != 0;
             this->stateStart    = (this->buttonMasks & WPAD_BUTTON_PLUS) != 0;
             this->stateSelect   = (this->buttonMasks & WPAD_BUTTON_MINUS) != 0;
-            this->stateUp       |= (data->exp.nunchuk.js.pos.y > data->exp.nunchuk.js.center.y + 5) ? 1 : 0;
-            this->stateDown     |= (data->exp.nunchuk.js.pos.y < data->exp.nunchuk.js.center.y - 5) ? 1 : 0;
-            this->stateLeft     |= (data->exp.nunchuk.js.pos.x < data->exp.nunchuk.js.center.x - 5) ? 1 : 0;
-            this->stateRight    |= (data->exp.nunchuk.js.pos.x > data->exp.nunchuk.js.center.x + 5) ? 1 : 0;
+            this->stateUp       |= (data->exp.nunchuk.js.pos.y > data->exp.nunchuk.js.center.y + 10) ? 1 : 0;
+            this->stateDown     |= (data->exp.nunchuk.js.pos.y < data->exp.nunchuk.js.center.y - 10) ? 1 : 0;
+            this->stateLeft     |= (data->exp.nunchuk.js.pos.x < data->exp.nunchuk.js.center.x - 10) ? 1 : 0;
+            this->stateRight    |= (data->exp.nunchuk.js.pos.x > data->exp.nunchuk.js.center.x + 10) ? 1 : 0;
             break;
         case WPAD_EXP_CLASSIC:
             this->stateUp       = (this->buttonMasks & WPAD_CLASSIC_BUTTON_UP) != 0;

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
@@ -35,6 +35,10 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
         this->stateZ      |= (this->buttonMasks & 0) != 0;
         this->stateStart  |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_PLUS) != 0;
         this->stateSelect |= (this->buttonMasks & WPAD_CLASSIC_BUTTON_MINUS) != 0;	
+        this->stateUp |= (data->exp.classic.ljs.pos.y > data->exp.classic.ljs.center.y + 5) ? 1 : 0;
+        this->stateDown |= (data->exp.classic.ljs.pos.y < data->exp.classic.ljs.center.y - 5) ? 1 : 0;
+        this->stateLeft |= (data->exp.classic.ljs.pos.x < data->exp.classic.ljs.center.x - 5) ? 1 : 0;
+        this->stateRight |= (data->exp.classic.ljs.pos.x > data->exp.classic.ljs.center.x + 5) ? 1 : 0;
     }
     // Update both
     this->ProcessInput(CONT_ANY);

--- a/RSDKv5/RSDK/User/Core/UserCore.cpp
+++ b/RSDKv5/RSDK/User/Core/UserCore.cpp
@@ -316,7 +316,11 @@ void RSDK::LoadSettingsINI()
         customSettings.region                    = iniparser_getint(ini, "Game:region", -1);
         // customSettings.confirmButtonFlip         = iniparser_getboolean(ini, "Game:confirmButtonFlip", false);
         // customSettings.xyButtonFlip              = iniparser_getboolean(ini, "Game:xyButtonFlip", false);
-        customSettings.confirmButtonFlip         = iniparser_getboolean(ini, "Game:faceButtonFlip", false);
+#if RETRO_PLATFORM == RETRO_WII
+        customSettings.confirmButtonFlip = true;
+#else
+        customSettings.confirmButtonFlip = iniparser_getboolean(ini, "Game:faceButtonFlip", false);
+#endif
         customSettings.xyButtonFlip              = customSettings.confirmButtonFlip;
         customSettings.enableControllerDebugging = iniparser_getboolean(ini, "Game:enableControllerDebugging", false);
         customSettings.disableFocusPause         = iniparser_getboolean(ini, "Game:disableFocusPause", false);

--- a/RSDKv5/RSDK/User/Core/UserCore.cpp
+++ b/RSDKv5/RSDK/User/Core/UserCore.cpp
@@ -500,7 +500,11 @@ void RSDK::LoadSettingsINI()
 
 #if !RETRO_USE_ORIGINAL_CODE
         customSettings.region                    = -1;
+#if RETRO_PLATFORM = RETRO_WII
         customSettings.confirmButtonFlip         = true;
+#else
+        customSettings.confirmButtonFlip         = false;
+#endif
         customSettings.xyButtonFlip              = false;
         customSettings.enableControllerDebugging = false;
         customSettings.disableFocusPause         = false;

--- a/RSDKv5/RSDK/User/Core/UserCore.cpp
+++ b/RSDKv5/RSDK/User/Core/UserCore.cpp
@@ -500,7 +500,7 @@ void RSDK::LoadSettingsINI()
 
 #if !RETRO_USE_ORIGINAL_CODE
         customSettings.region                    = -1;
-        customSettings.confirmButtonFlip         = false;
+        customSettings.confirmButtonFlip         = true;
         customSettings.xyButtonFlip              = false;
         customSettings.enableControllerDebugging = false;
         customSettings.disableFocusPause         = false;
@@ -614,7 +614,7 @@ void RSDK::SaveSettingsINI(bool32 writeToFile)
 #else
         WriteText(file, "language=%d\n", gameVerInfo.language);
 #endif
-
+	WriteText(file, "faceButtonFlip=%s\n", (customSettings.confirmButtonFlip ? "y" : "n"));
         // ================
         // VIDEO
         // ================

--- a/RSDKv5/RSDK/User/Core/UserCore.cpp
+++ b/RSDKv5/RSDK/User/Core/UserCore.cpp
@@ -614,7 +614,9 @@ void RSDK::SaveSettingsINI(bool32 writeToFile)
 #else
         WriteText(file, "language=%d\n", gameVerInfo.language);
 #endif
+#if RETRO_PLATFORM == RETRO_WII
 	WriteText(file, "faceButtonFlip=%s\n", (customSettings.confirmButtonFlip ? "y" : "n"));
+#endif
         // ================
         // VIDEO
         // ================

--- a/RSDKv5/RSDK/User/Core/UserCore.cpp
+++ b/RSDKv5/RSDK/User/Core/UserCore.cpp
@@ -500,7 +500,7 @@ void RSDK::LoadSettingsINI()
 
 #if !RETRO_USE_ORIGINAL_CODE
         customSettings.region                    = -1;
-#if RETRO_PLATFORM = RETRO_WII
+#if RETRO_PLATFORM == RETRO_WII
         customSettings.confirmButtonFlip         = true;
 #else
         customSettings.confirmButtonFlip         = false;


### PR DESCRIPTION
Adds Wii classic controller support. Buttons are inverted to be correct with the GUI. Analog sticks are supported now, deadzone might need adjusting. Tested on real hardware with snes classic controller. Also now supports the wii nunchuk, tested on real hardware.