### PR TITLE
Gamecube controller and true analog stick support

### DIFF
--- a/RSDKv5/RSDK/Graphics/GX/GXRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/GX/GXRenderDevice.cpp
@@ -268,8 +268,9 @@ void RenderDevice::SetupVideoTexture_YUV444(int32 width, int32 height, uint8 *yP
 bool RenderDevice::ProcessEvents() {
     // Close when pressing home
     // FIXME: Maybe this should go in WiiInputDevice, but stopping the engine here makes more sense
+    u16 ButtonsHeldGC = PAD_ButtonsHeld(0);
     if (WPAD_ButtonsHeld(0) & (WPAD_BUTTON_HOME | WPAD_CLASSIC_BUTTON_HOME)
-        || (PAD_ButtonsHeld(0) & PAD_BUTTON_START && PAD_ButtonsHeld(0) & PAD_TRIGGER_L && PAD_ButtonsHeld(0) & PAD_TRIGGER_R)) {
+        || (ButtonsHeldGC & PAD_BUTTON_START && ButtonsHeldGC & PAD_TRIGGER_L && ButtonsHeldGC & PAD_TRIGGER_R)) {
         isRunning = false;
     }
 

--- a/RSDKv5/RSDK/Graphics/GX/GXRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/GX/GXRenderDevice.cpp
@@ -268,7 +268,8 @@ void RenderDevice::SetupVideoTexture_YUV444(int32 width, int32 height, uint8 *yP
 bool RenderDevice::ProcessEvents() {
     // Close when pressing home
     // FIXME: Maybe this should go in WiiInputDevice, but stopping the engine here makes more sense
-    if (WPAD_ButtonsHeld(0) & (WPAD_BUTTON_HOME | WPAD_CLASSIC_BUTTON_HOME) || PAD_ButtonsHeld(0) & PAD_BUTTON_START) {
+    if (WPAD_ButtonsHeld(0) & (WPAD_BUTTON_HOME | WPAD_CLASSIC_BUTTON_HOME)
+        || (PAD_ButtonsHeld(0) & PAD_BUTTON_START && PAD_ButtonsHeld(0) & PAD_TRIGGER_L && PAD_ButtonsHeld(0) & PAD_TRIGGER_R)) {
         isRunning = false;
     }
 

--- a/RSDKv5/RSDK/Graphics/GX/GXRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/GX/GXRenderDevice.cpp
@@ -268,7 +268,7 @@ void RenderDevice::SetupVideoTexture_YUV444(int32 width, int32 height, uint8 *yP
 bool RenderDevice::ProcessEvents() {
     // Close when pressing home
     // FIXME: Maybe this should go in WiiInputDevice, but stopping the engine here makes more sense
-    if (WPAD_ButtonsHeld(0) & (WPAD_BUTTON_HOME | WPAD_CLASSIC_BUTTON_HOME)) {
+    if (WPAD_ButtonsHeld(0) & (WPAD_BUTTON_HOME | WPAD_CLASSIC_BUTTON_HOME) || PAD_ButtonsHeld(0) & PAD_BUTTON_START) {
         isRunning = false;
     }
 

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
@@ -5,61 +5,84 @@ using namespace RSDK;
 void RSDK::SKU::InputDeviceWii::UpdateInput() {
     WPAD_ScanPads();
 
-    this->buttonMasks = WPAD_ButtonsHeld(0);
+    this->buttonMasksWii = WPAD_ButtonsHeld(0);
     WPADData *data = WPAD_Data(0);
     int type = data->exp.type;
     switch (type) {
-        case WPAD_EXP_NONE: default:
-            this->stateUp     = (this->buttonMasks & WPAD_BUTTON_RIGHT) != 0;
-            this->stateDown   = (this->buttonMasks & WPAD_BUTTON_LEFT) != 0;
-            this->stateLeft   = (this->buttonMasks & WPAD_BUTTON_UP) != 0;
-            this->stateRight  = (this->buttonMasks & WPAD_BUTTON_DOWN) != 0;
-            this->stateA      = (this->buttonMasks & WPAD_BUTTON_1) != 0;
-            this->stateB      = (this->buttonMasks & WPAD_BUTTON_2) != 0;
-            this->stateC      = (this->buttonMasks & 0) != 0;
-            this->stateX      = (this->buttonMasks & WPAD_BUTTON_B) != 0;
-            this->stateY      = (this->buttonMasks & WPAD_BUTTON_A) != 0;
-            this->stateZ      = (this->buttonMasks & 0) != 0;
-            this->stateStart  = (this->buttonMasks & WPAD_BUTTON_PLUS) != 0;
-            this->stateSelect = (this->buttonMasks & WPAD_BUTTON_MINUS) != 0;
+        case WPAD_EXP_NONE:
+        default:
+            this->stateUp     = (this->buttonMasksWii & WPAD_BUTTON_RIGHT) != 0;
+            this->stateDown   = (this->buttonMasksWii & WPAD_BUTTON_LEFT) != 0;
+            this->stateLeft   = (this->buttonMasksWii & WPAD_BUTTON_UP) != 0;
+            this->stateRight  = (this->buttonMasksWii & WPAD_BUTTON_DOWN) != 0;
+            this->stateA      = (this->buttonMasksWii & WPAD_BUTTON_1) != 0;
+            this->stateB      = (this->buttonMasksWii & WPAD_BUTTON_2) != 0;
+            this->stateC      = (this->buttonMasksWii & 0) != 0;
+            this->stateX      = (this->buttonMasksWii & WPAD_BUTTON_B) != 0;
+            this->stateY      = (this->buttonMasksWii & WPAD_BUTTON_A) != 0;
+            this->stateZ      = (this->buttonMasksWii & 0) != 0;
+            this->stateStart  = (this->buttonMasksWii & WPAD_BUTTON_PLUS) != 0;
+            this->stateSelect = (this->buttonMasksWii & WPAD_BUTTON_MINUS) != 0;
             break;
         case WPAD_EXP_NUNCHUK:
-            this->stateUp       = (this->buttonMasks & WPAD_BUTTON_UP) != 0;
-            this->stateDown     = (this->buttonMasks & WPAD_BUTTON_DOWN) != 0;
-            this->stateLeft     = (this->buttonMasks & WPAD_BUTTON_LEFT) != 0;
-            this->stateRight    = (this->buttonMasks & WPAD_BUTTON_RIGHT) != 0;
-            this->stateA        = (this->buttonMasks & WPAD_BUTTON_B) != 0;
-            this->stateB        = (this->buttonMasks & WPAD_BUTTON_A) != 0;
-            this->stateC        = (this->buttonMasks & 0) != 0;
-            this->stateX        = (this->buttonMasks & WPAD_NUNCHUK_BUTTON_C) != 0;
-            this->stateY        = (this->buttonMasks & WPAD_NUNCHUK_BUTTON_Z) != 0;
-            this->stateZ        = (this->buttonMasks & 0) != 0;
-            this->stateStart    = (this->buttonMasks & WPAD_BUTTON_PLUS) != 0;
-            this->stateSelect   = (this->buttonMasks & WPAD_BUTTON_MINUS) != 0;
-            this->stateUp       |= (data->exp.nunchuk.js.pos.y > data->exp.nunchuk.js.center.y + 15) ? 1 : 0;
-            this->stateDown     |= (data->exp.nunchuk.js.pos.y < data->exp.nunchuk.js.center.y - 15) ? 1 : 0;
-            this->stateLeft     |= (data->exp.nunchuk.js.pos.x < data->exp.nunchuk.js.center.x - 15) ? 1 : 0;
-            this->stateRight    |= (data->exp.nunchuk.js.pos.x > data->exp.nunchuk.js.center.x + 15) ? 1 : 0;
+            this->stateUp     = (this->buttonMasksWii & WPAD_BUTTON_UP) != 0;
+            this->stateDown   = (this->buttonMasksWii & WPAD_BUTTON_DOWN) != 0;
+            this->stateLeft   = (this->buttonMasksWii & WPAD_BUTTON_LEFT) != 0;
+            this->stateRight  = (this->buttonMasksWii & WPAD_BUTTON_RIGHT) != 0;
+            this->stateA      = (this->buttonMasksWii & WPAD_BUTTON_B) != 0;
+            this->stateB      = (this->buttonMasksWii & WPAD_BUTTON_A) != 0;
+            this->stateC      = (this->buttonMasksWii & 0) != 0;
+            this->stateX      = (this->buttonMasksWii & WPAD_NUNCHUK_BUTTON_C) != 0;
+            this->stateY      = (this->buttonMasksWii & WPAD_NUNCHUK_BUTTON_Z) != 0;
+            this->stateZ      = (this->buttonMasksWii & 0) != 0;
+            this->stateStart  = (this->buttonMasksWii & WPAD_BUTTON_PLUS) != 0;
+            this->stateSelect = (this->buttonMasksWii & WPAD_BUTTON_MINUS) != 0;
+            this->stateUp |= (data->exp.nunchuk.js.pos.y > data->exp.nunchuk.js.center.y + 10) ? 1 : 0;
+            this->stateDown |= (data->exp.nunchuk.js.pos.y < data->exp.nunchuk.js.center.y - 10) ? 1 : 0;
+            this->stateLeft |= (data->exp.nunchuk.js.pos.x < data->exp.nunchuk.js.center.x - 10) ? 1 : 0;
+            this->stateRight |= (data->exp.nunchuk.js.pos.x > data->exp.nunchuk.js.center.x + 10) ? 1 : 0;
             break;
         case WPAD_EXP_CLASSIC:
-            this->stateUp       = (this->buttonMasks & WPAD_CLASSIC_BUTTON_UP) != 0;
-            this->stateDown     = (this->buttonMasks & WPAD_CLASSIC_BUTTON_DOWN) != 0;
-            this->stateLeft     = (this->buttonMasks & WPAD_CLASSIC_BUTTON_LEFT) != 0;
-            this->stateRight    = (this->buttonMasks & WPAD_CLASSIC_BUTTON_RIGHT) != 0;
-            this->stateA        = (this->buttonMasks & WPAD_CLASSIC_BUTTON_B) != 0;
-            this->stateB        = (this->buttonMasks & WPAD_CLASSIC_BUTTON_A) != 0;
-            this->stateC        = (this->buttonMasks & 0) != 0;
-            this->stateX        = (this->buttonMasks & WPAD_CLASSIC_BUTTON_Y) != 0;
-            this->stateY        = (this->buttonMasks & WPAD_CLASSIC_BUTTON_X) != 0;
-            this->stateZ        = (this->buttonMasks & 0) != 0;
-            this->stateStart    = (this->buttonMasks & WPAD_CLASSIC_BUTTON_PLUS) != 0;
-            this->stateSelect   = (this->buttonMasks & WPAD_CLASSIC_BUTTON_MINUS) != 0;
-            this->stateUp       |= (data->exp.classic.ljs.pos.y > data->exp.classic.ljs.center.y + 5) ? 1 : 0;
-            this->stateDown     |= (data->exp.classic.ljs.pos.y < data->exp.classic.ljs.center.y - 5) ? 1 : 0;
-            this->stateLeft     |= (data->exp.classic.ljs.pos.x < data->exp.classic.ljs.center.x - 5) ? 1 : 0;
-            this->stateRight    |= (data->exp.classic.ljs.pos.x > data->exp.classic.ljs.center.x + 5) ? 1 : 0;
+            this->stateUp     = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_UP) != 0;
+            this->stateDown   = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_DOWN) != 0;
+            this->stateLeft   = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_LEFT) != 0;
+            this->stateRight  = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_RIGHT) != 0;
+            this->stateA      = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_B) != 0;
+            this->stateB      = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_A) != 0;
+            this->stateC      = (this->buttonMasksWii & 0) != 0;
+            this->stateX      = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_Y) != 0;
+            this->stateY      = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_X) != 0;
+            this->stateZ      = (this->buttonMasksWii & 0) != 0;
+            this->stateStart  = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_PLUS) != 0;
+            this->stateSelect = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_MINUS) != 0;
+            this->stateUp |= (data->exp.classic.ljs.pos.y > data->exp.classic.ljs.center.y + 5) ? 1 : 0;
+            this->stateDown |= (data->exp.classic.ljs.pos.y < data->exp.classic.ljs.center.y - 5) ? 1 : 0;
+            this->stateLeft |= (data->exp.classic.ljs.pos.x < data->exp.classic.ljs.center.x - 5) ? 1 : 0;
+            this->stateRight |= (data->exp.classic.ljs.pos.x > data->exp.classic.ljs.center.x + 5) ? 1 : 0;
             break;
     }
+    if(PAD_ScanPads() > 0)
+    {
+        this->buttonMasksGC = PAD_ButtonsHeld(0);
+        
+        this->stateUp     = (this->buttonMasksGC & PAD_BUTTON_UP) != 0;
+        this->stateDown   = (this->buttonMasksGC & PAD_BUTTON_DOWN) != 0;
+        this->stateLeft   = (this->buttonMasksGC & PAD_BUTTON_LEFT) != 0;
+        this->stateRight  = (this->buttonMasksGC & PAD_BUTTON_RIGHT) != 0;
+        this->stateA      = (this->buttonMasksGC & PAD_BUTTON_B) != 0;
+        this->stateB      = (this->buttonMasksGC & PAD_BUTTON_A) != 0;
+        this->stateC      = (this->buttonMasksGC & 0) != 0;
+        this->stateX      = (this->buttonMasksGC & PAD_BUTTON_Y) != 0;
+        this->stateY      = (this->buttonMasksGC & PAD_BUTTON_X) != 0;
+        this->stateZ      = (this->buttonMasksGC & 0) != 0;
+        this->stateStart  = (this->buttonMasksGC & PAD_BUTTON_START) != 0;
+        this->stateSelect = (this->buttonMasksGC & PAD_TRIGGER_Z) != 0;
+        this->stateUp |= (PAD_StickY(0) > 10) ? 1 : 0;
+        this->stateDown |= (PAD_StickY(0) < -10) ? 1 : 0;
+        this->stateLeft |= (PAD_StickX(0) < -10) ? 1 : 0;
+        this->stateRight |= (PAD_StickX(0) > 10) ? 1 : 0;
+    }
+
     // Update both
     this->ProcessInput(CONT_ANY);
     this->ProcessInput(CONT_P1);
@@ -120,5 +143,6 @@ RSDK::SKU::InputDeviceWii *RSDK::SKU::InitWiiInputDevice(uint32 id) {
 
 void RSDK::SKU::InitWiiInputAPI() {
     WPAD_Init();
+    PAD_Init();
     SKU::InitWiiInputDevice(CONT_P1);
 }

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
@@ -37,10 +37,10 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
             this->stateZ      = (this->buttonMasksWii & 0) != 0;
             this->stateStart  = (this->buttonMasksWii & WPAD_BUTTON_PLUS) != 0;
             this->stateSelect = (this->buttonMasksWii & WPAD_BUTTON_MINUS) != 0;
-            this->stateUp |= (data->exp.nunchuk.js.pos.y > data->exp.nunchuk.js.center.y + 10) ? 1 : 0;
-            this->stateDown |= (data->exp.nunchuk.js.pos.y < data->exp.nunchuk.js.center.y - 10) ? 1 : 0;
-            this->stateLeft |= (data->exp.nunchuk.js.pos.x < data->exp.nunchuk.js.center.x - 10) ? 1 : 0;
-            this->stateRight |= (data->exp.nunchuk.js.pos.x > data->exp.nunchuk.js.center.x + 10) ? 1 : 0;
+            this->stateUp     |= (data->exp.nunchuk.js.pos.y > data->exp.nunchuk.js.center.y + 15) ? 1 : 0;
+            this->stateDown   |= (data->exp.nunchuk.js.pos.y < data->exp.nunchuk.js.center.y - 15) ? 1 : 0;
+            this->stateLeft   |= (data->exp.nunchuk.js.pos.x < data->exp.nunchuk.js.center.x - 15) ? 1 : 0;
+            this->stateRight  |= (data->exp.nunchuk.js.pos.x > data->exp.nunchuk.js.center.x + 15) ? 1 : 0;
             break;
         case WPAD_EXP_CLASSIC:
             this->stateUp     = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_UP) != 0;
@@ -55,10 +55,10 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
             this->stateZ      = (this->buttonMasksWii & 0) != 0;
             this->stateStart  = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_PLUS) != 0;
             this->stateSelect = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_MINUS) != 0;
-            this->stateUp |= (data->exp.classic.ljs.pos.y > data->exp.classic.ljs.center.y + 5) ? 1 : 0;
-            this->stateDown |= (data->exp.classic.ljs.pos.y < data->exp.classic.ljs.center.y - 5) ? 1 : 0;
-            this->stateLeft |= (data->exp.classic.ljs.pos.x < data->exp.classic.ljs.center.x - 5) ? 1 : 0;
-            this->stateRight |= (data->exp.classic.ljs.pos.x > data->exp.classic.ljs.center.x + 5) ? 1 : 0;
+            this->stateUp     |= (data->exp.classic.ljs.pos.y > data->exp.classic.ljs.center.y + 5) ? 1 : 0;
+            this->stateDown   |= (data->exp.classic.ljs.pos.y < data->exp.classic.ljs.center.y - 5) ? 1 : 0;
+            this->stateLeft   |= (data->exp.classic.ljs.pos.x < data->exp.classic.ljs.center.x - 5) ? 1 : 0;
+            this->stateRight  |= (data->exp.classic.ljs.pos.x > data->exp.classic.ljs.center.x + 5) ? 1 : 0;
             break;
     }
     if(PAD_ScanPads() > 0)
@@ -77,10 +77,10 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
         this->stateZ      = (this->buttonMasksGC & 0) != 0;
         this->stateStart  = (this->buttonMasksGC & PAD_BUTTON_START) != 0;
         this->stateSelect = (this->buttonMasksGC & PAD_TRIGGER_Z) != 0;
-        this->stateUp |= (PAD_StickY(0) > 10) ? 1 : 0;
-        this->stateDown |= (PAD_StickY(0) < -10) ? 1 : 0;
-        this->stateLeft |= (PAD_StickX(0) < -10) ? 1 : 0;
-        this->stateRight |= (PAD_StickX(0) > 10) ? 1 : 0;
+        this->stateUp     |= (PAD_StickY(0) > 10) ? 1 : 0;
+        this->stateDown   |= (PAD_StickY(0) < -10) ? 1 : 0;
+        this->stateLeft   |= (PAD_StickX(0) < -10) ? 1 : 0;
+        this->stateRight  |= (PAD_StickX(0) > 10) ? 1 : 0;
     }
 
     // Update both

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
@@ -3,7 +3,7 @@
 using namespace RSDK;
 
 void RSDK::SKU::InputDeviceWii::UpdateInput() {
-    WPAD_ScanPads();
+    s32 WiiPads = WPAD_ScanPads();
 
     this->buttonMasksWii = WPAD_ButtonsHeld(0);
     WPADData *data = WPAD_Data(0);
@@ -61,7 +61,7 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
             this->stateRight  |= (data->exp.classic.ljs.pos.x > data->exp.classic.ljs.center.x + 5) ? 1 : 0;
             break;
     }
-    if(PAD_ScanPads() > 0) //checks if a gamecube controller is plugged into the wii
+    if (PAD_ScanPads() > 0 && WiiPads < 1) // checks if a gamecube controller is plugged into the wii and if there is no wiimote connected
     {
         this->buttonMasksGC = PAD_ButtonsHeld(0);
         

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
@@ -1,5 +1,7 @@
 #include <wiiuse/wpad.h>
 
+#define JSMAXGC 101.0f //maximum left joystick value for gamecube controller
+
 using namespace RSDK;
 
 void RSDK::SKU::InputDeviceWii::UpdateInput() {
@@ -37,8 +39,8 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
             this->stateZ      = (this->buttonMasksWii & 0) != 0;
             this->stateStart  = (this->buttonMasksWii & WPAD_BUTTON_PLUS) != 0;
             this->stateSelect = (this->buttonMasksWii & WPAD_BUTTON_MINUS) != 0;
-            this->vDelta_L    = (float)(data->exp.nunchuk.js.pos.y - data->exp.nunchuk.js.center.y) / (data->exp.nunchuk.js.max.y / 2);
-            this->hDelta_L    = (float)(data->exp.nunchuk.js.pos.x - data->exp.nunchuk.js.center.x) / (data->exp.nunchuk.js.max.x / 2);
+            this->vDelta_L    = (float)(data->exp.nunchuk.js.pos.y - data->exp.nunchuk.js.center.y) / ((float)data->exp.nunchuk.js.max.y / 2.0f);
+            this->hDelta_L    = (float)(data->exp.nunchuk.js.pos.x - data->exp.nunchuk.js.center.x) / ((float)data->exp.nunchuk.js.max.x / 2.0f);
             break;
         case WPAD_EXP_CLASSIC:
             this->stateUp     = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_UP) != 0;
@@ -53,8 +55,8 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
             this->stateZ      = (this->buttonMasksWii & 0) != 0;
             this->stateStart  = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_PLUS) != 0;
             this->stateSelect = (this->buttonMasksWii & WPAD_CLASSIC_BUTTON_MINUS) != 0;
-            this->vDelta_L    = (float)(data->exp.classic.ljs.pos.y - data->exp.classic.ljs.center.y) / (data->exp.classic.ljs.max.y / 2);
-            this->hDelta_L    = (float)(data->exp.classic.ljs.pos.x - data->exp.classic.ljs.center.x) / (data->exp.classic.ljs.max.x / 2);
+            this->vDelta_L    = (float)(data->exp.classic.ljs.pos.y - data->exp.classic.ljs.center.y) / ((float)data->exp.classic.ljs.max.y / 2.0f);
+            this->hDelta_L    = (float)(data->exp.classic.ljs.pos.x - data->exp.classic.ljs.center.x) / ((float)data->exp.classic.ljs.max.x / 2.0f);
             break;
     }
     if (PAD_ScanPads() > 0) // checks if a gamecube controller is plugged into the wii
@@ -73,8 +75,8 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
         this->stateZ      |= (this->buttonMasksGC & 0) != 0;
         this->stateStart  |= (this->buttonMasksGC & PAD_BUTTON_START) != 0;
         this->stateSelect |= (this->buttonMasksGC & PAD_TRIGGER_Z) != 0;
-        this->vDelta_L = (float)PAD_StickY(0) / (101 / 2);
-        this->hDelta_L = (float)PAD_StickX(0) / (101 / 2);
+        this->vDelta_L = (float)PAD_StickY(0) / (JSMAXGC / 2.0f);
+        this->hDelta_L = (float)PAD_StickX(0) / (JSMAXGC / 2.0f);
     }
 
     // Update both

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.cpp
@@ -61,22 +61,22 @@ void RSDK::SKU::InputDeviceWii::UpdateInput() {
             this->stateRight  |= (data->exp.classic.ljs.pos.x > data->exp.classic.ljs.center.x + 5) ? 1 : 0;
             break;
     }
-    if (PAD_ScanPads() > 0 && WiiPads < 1) // checks if a gamecube controller is plugged into the wii and if there is no wiimote connected
+    if (PAD_ScanPads() > 0) // checks if a gamecube controller is plugged into the wii
     {
         this->buttonMasksGC = PAD_ButtonsHeld(0);
         
-        this->stateUp     = (this->buttonMasksGC & PAD_BUTTON_UP) != 0;
-        this->stateDown   = (this->buttonMasksGC & PAD_BUTTON_DOWN) != 0;
-        this->stateLeft   = (this->buttonMasksGC & PAD_BUTTON_LEFT) != 0;
-        this->stateRight  = (this->buttonMasksGC & PAD_BUTTON_RIGHT) != 0;
-        this->stateA      = (this->buttonMasksGC & PAD_BUTTON_B) != 0;
-        this->stateB      = (this->buttonMasksGC & PAD_BUTTON_A) != 0;
-        this->stateC      = (this->buttonMasksGC & 0) != 0;
-        this->stateX      = (this->buttonMasksGC & PAD_BUTTON_Y) != 0;
-        this->stateY      = (this->buttonMasksGC & PAD_BUTTON_X) != 0;
-        this->stateZ      = (this->buttonMasksGC & 0) != 0;
-        this->stateStart  = (this->buttonMasksGC & PAD_BUTTON_START) != 0;
-        this->stateSelect = (this->buttonMasksGC & PAD_TRIGGER_Z) != 0;
+        this->stateUp     |= (this->buttonMasksGC & PAD_BUTTON_UP) != 0;
+        this->stateDown   |= (this->buttonMasksGC & PAD_BUTTON_DOWN) != 0;
+        this->stateLeft   |= (this->buttonMasksGC & PAD_BUTTON_LEFT) != 0;
+        this->stateRight  |= (this->buttonMasksGC & PAD_BUTTON_RIGHT) != 0;
+        this->stateA      |= (this->buttonMasksGC & PAD_BUTTON_B) != 0;
+        this->stateB      |= (this->buttonMasksGC & PAD_BUTTON_A) != 0;
+        this->stateC      |= (this->buttonMasksGC & 0) != 0;
+        this->stateX      |= (this->buttonMasksGC & PAD_BUTTON_Y) != 0;
+        this->stateY      |= (this->buttonMasksGC & PAD_BUTTON_X) != 0;
+        this->stateZ      |= (this->buttonMasksGC & 0) != 0;
+        this->stateStart  |= (this->buttonMasksGC & PAD_BUTTON_START) != 0;
+        this->stateSelect |= (this->buttonMasksGC & PAD_TRIGGER_Z) != 0;
         this->stateUp     |= (PAD_StickY(0) > 10) ? 1 : 0;
         this->stateDown   |= (PAD_StickY(0) < -10) ? 1 : 0;
         this->stateLeft   |= (PAD_StickX(0) < -10) ? 1 : 0;

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.hpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.hpp
@@ -8,8 +8,6 @@ struct InputDeviceWii : InputDevice {
 
     uint32 buttonMasksWii;
     uint16 buttonMasksGC;
-    uint32 prevButtonMasksWii;
-    uint16 prevButtonMasksGC;
     uint8 stateUp;
     uint8 stateDown;
     uint8 stateLeft;

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.hpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.hpp
@@ -20,6 +20,8 @@ struct InputDeviceWii : InputDevice {
     uint8 stateZ;
     uint8 stateStart;
     uint8 stateSelect;
+    float hDelta_L;
+    float vDelta_L;
 };
 
 void InitWiiInputAPI();

--- a/RSDKv5/RSDK/Input/Wii/WiiInputDevice.hpp
+++ b/RSDKv5/RSDK/Input/Wii/WiiInputDevice.hpp
@@ -6,8 +6,10 @@ struct InputDeviceWii : InputDevice {
     void ProcessInput(int32 controllerID);
     void CloseDevice();
 
-    uint32 buttonMasks;
-    uint32 prevButtonMasks;
+    uint32 buttonMasksWii;
+    uint16 buttonMasksGC;
+    uint32 prevButtonMasksWii;
+    uint16 prevButtonMasksGC;
     uint8 stateUp;
     uint8 stateDown;
     uint8 stateLeft;


### PR DESCRIPTION
Adds Gamecube controller support. Buttons are correct with GUI. Basic analog stick support, deadzone might need adjusting though. Tested on real hardware with smash bros ultimate Gamecube controller.