### PR TITLE
Added 240p rendering support & a settings.ini config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,5 @@ Ignored/
 android/local.properties
 
 *.res
+
+.map

--- a/.gitignore
+++ b/.gitignore
@@ -246,5 +246,3 @@ Ignored/
 android/local.properties
 
 *.res
-
-.map

--- a/RSDKv5/RSDK/Graphics/Drawing.cpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.cpp
@@ -442,9 +442,6 @@ int32 RSDK::GetVideoSetting(int32 id)
             return gameVerInfo.language;
 #endif
         case VIDEOSETTING_CHANGED: return changedVideoSettings;
-#if RETRO_PLATFORM == RETRO_WII
-        case VIDEOSETTING_RUNIN240P: return videoSettings.runIn240p;
-#endif
 
         default: break;
     }
@@ -456,15 +453,6 @@ void RSDK::SetVideoSetting(int32 id, int32 value)
 {
     bool32 boolVal = value;
     switch (id) {
-#if RETRO_PLATFORM == RETRO_WII
-        case VIDEOSETTING_RUNIN240P:
-            if (videoSettings.runIn240p != boolVal) {
-                videoSettings.runIn240p = boolVal;
-                changedVideoSettings    = true;
-            }
-            break;
-#endif
-
         case VIDEOSETTING_WINDOWED:
             if (videoSettings.windowed != boolVal) {
                 videoSettings.windowed = boolVal;

--- a/RSDKv5/RSDK/Graphics/Drawing.cpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.cpp
@@ -442,6 +442,9 @@ int32 RSDK::GetVideoSetting(int32 id)
             return gameVerInfo.language;
 #endif
         case VIDEOSETTING_CHANGED: return changedVideoSettings;
+#if RETRO_PLATFORM == RETRO_WII
+        case VIDEOSETTING_RUNIN240P: return videoSettings.runIn240p;
+#endif
 
         default: break;
     }
@@ -453,6 +456,15 @@ void RSDK::SetVideoSetting(int32 id, int32 value)
 {
     bool32 boolVal = value;
     switch (id) {
+#if RETRO_PLATFORM == RETRO_WII
+        case VIDEOSETTING_RUNIN240P:
+            if (videoSettings.runIn240p != boolVal) {
+                videoSettings.runIn240p = boolVal;
+                changedVideoSettings    = true;
+            }
+            break;
+#endif
+
         case VIDEOSETTING_WINDOWED:
             if (videoSettings.windowed != boolVal) {
                 videoSettings.windowed = boolVal;

--- a/RSDKv5/RSDK/Graphics/Drawing.hpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.hpp
@@ -126,6 +126,9 @@ struct VideoSettings {
     float viewportH;
     float viewportX;
     float viewportY;
+#if RETRO_PLATFORM == RETRO_WII
+    bool runIn240p;
+#endif
 };
 
 enum VideoSettingsValues {
@@ -153,6 +156,9 @@ enum VideoSettingsValues {
     VIDEOSETTING_RELOAD,
     VIDEOSETTING_CHANGED,
     VIDEOSETTING_WRITE,
+#if RETRO_PLATFORM == RETRO_WII
+    VIDEOSETTING_RUNIN240P,
+#endif
 };
 
 struct float4 {

--- a/RSDKv5/RSDK/Graphics/Drawing.hpp
+++ b/RSDKv5/RSDK/Graphics/Drawing.hpp
@@ -156,9 +156,6 @@ enum VideoSettingsValues {
     VIDEOSETTING_RELOAD,
     VIDEOSETTING_CHANGED,
     VIDEOSETTING_WRITE,
-#if RETRO_PLATFORM == RETRO_WII
-    VIDEOSETTING_RUNIN240P,
-#endif
 };
 
 struct float4 {

--- a/RSDKv5/RSDK/Graphics/GX/GXRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/GX/GXRenderDevice.cpp
@@ -71,7 +71,7 @@ bool RenderDevice::Init() {
         }
     }
     else {
-        vmode = &TVMpal240Ds;
+        vmode = &TVNtsc240Ds;
         viewWidth = 640;
     }
 

--- a/RSDKv5/RSDK/Graphics/GX/GXRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/GX/GXRenderDevice.cpp
@@ -1,3 +1,4 @@
+#include "RSDK/Core/RetroEngine.hpp"
 #include <gccore.h>
 #include <malloc.h>
 #include <wiiuse/wpad.h>
@@ -50,21 +51,28 @@ draw_square() {
 bool RenderDevice::Init() {
     // Initialize the video system
     VIDEO_Init();
-    vmode = VIDEO_GetPreferredMode(NULL);
 
-    // Check for aspect ratio
-    if (CONF_GetAspectRatio() == CONF_ASPECT_16_9) {
-        vmode->viWidth = 672;
-        viewWidth = 848;
-    } else { // 4:3
-        viewWidth = 640;
+    if(!videoSettings.runIn240p) {
+        vmode = VIDEO_GetPreferredMode(NULL);
+
+        // Check for aspect ratio
+        if (CONF_GetAspectRatio() == CONF_ASPECT_16_9) {
+            vmode->viWidth = 672;
+            viewWidth = 848;
+        } else { // 4:3
+            viewWidth = 640;
+        }
+        if (vmode == &TVPal576IntDfScale || vmode == &TVPal576ProgScale) {
+            vmode->viXOrigin = (VI_MAX_WIDTH_PAL - vmode->viWidth) / 2;
+            vmode->viYOrigin = (VI_MAX_HEIGHT_PAL - vmode->viHeight) / 2;
+        } else {
+            vmode->viXOrigin = (VI_MAX_WIDTH_NTSC - vmode->viWidth) / 2;
+            vmode->viYOrigin = (VI_MAX_HEIGHT_NTSC - vmode->viHeight) / 2;
+        }
     }
-    if (vmode == &TVPal576IntDfScale || vmode == &TVPal576ProgScale) {
-        vmode->viXOrigin = (VI_MAX_WIDTH_PAL - vmode->viWidth) / 2;
-        vmode->viYOrigin = (VI_MAX_HEIGHT_PAL - vmode->viHeight) / 2;
-    } else {
-        vmode->viXOrigin = (VI_MAX_WIDTH_NTSC - vmode->viWidth) / 2;
-        vmode->viYOrigin = (VI_MAX_HEIGHT_NTSC - vmode->viHeight) / 2;
+    else {
+        vmode = &TVMpal240Ds;
+        viewWidth = 640;
     }
 
     // Set up the video system with the chosen mode

--- a/RSDKv5/RSDK/User/Core/UserCore.cpp
+++ b/RSDKv5/RSDK/User/Core/UserCore.cpp
@@ -363,7 +363,11 @@ void RSDK::LoadSettingsINI()
         videoSettings.shaderID      = iniparser_getint(ini, "Video:screenShader", SHADER_NONE);
 
 #if !RETRO_USE_ORIGINAL_CODE
-        customSettings.maxPixWidth = iniparser_getint(ini, "Video:maxPixWidth", DEFAULT_PIXWIDTH);
+        customSettings.maxPixWidth  = iniparser_getint(ini, "Video:maxPixWidth", DEFAULT_PIXWIDTH);
+#endif
+
+#if RETRO_PLATFORM == RETRO_WII
+        videoSettings.runIn240p     = iniparser_getboolean(ini, "Video:runIn240p", false);
 #endif
 
         engine.streamsEnabled = iniparser_getboolean(ini, "Audio:streamsEnabled", true);
@@ -506,6 +510,9 @@ void RSDK::LoadSettingsINI()
         customSettings.region                    = -1;
 #if RETRO_PLATFORM == RETRO_WII
         customSettings.confirmButtonFlip         = true;
+
+        //default to not running in 240p on Wii
+        videoSettings.runIn240p                  = false;
 #else
         customSettings.confirmButtonFlip         = false;
 #endif
@@ -655,6 +662,9 @@ void RSDK::SaveSettingsINI(bool32 writeToFile)
 #if !RETRO_USE_ORIGINAL_CODE
         WriteText(file, "; Maximum width the screen will be allowed to be. A value of 0 will disable the maximum width\n");
         WriteText(file, "maxPixWidth=%d\n", customSettings.maxPixWidth);
+#endif
+#if RETRO_PLATFORM == RETRO_WII
+        WriteText(file, "runIn240p=%s\n", (videoSettings.runIn240p ? "y" : "n"));
 #endif
 
         // ================


### PR DESCRIPTION
As we discussed separately, here's a PR for adding 240p support to the Wii port of RSDKv5.
This feature is disabled by default. The user will have to manually edit settings.ini in order to enable the functionality. Default functionality is the system's resolution settings. 

Any feedback before merging is much appreciated, I'm a bit of a noob when it comes to Wii homebrew and C++ dev, but hopefully this meets expectations! ^^