### PR TITLE
wii: Respect aspect ratio in 240p mode

### DIFF
--- a/RSDKv5/RSDK/Graphics/GX/GXRenderDevice.cpp
+++ b/RSDKv5/RSDK/Graphics/GX/GXRenderDevice.cpp
@@ -104,7 +104,12 @@ bool RenderDevice::Init() {
         vmode = &TVEurgb60Hz240Ds;
         // Set correct viTVMode based on the current mode used, which should be compatible with both NTSC and PAL
         vmode->viTVMode = VI_TVMODE(VIDEO_GetPreferredMode(NULL)->viTVMode >> 2, VI_NON_INTERLACE);
-        viewWidth = 640;
+        // Check for aspect ratio even in 240p mode
+        if (CONF_GetAspectRatio() == CONF_ASPECT_16_9) {
+            viewWidth = 848;
+        } else { // 4:3
+            viewWidth = 640;
+        }
     }
 
     // Set up the video system with the chosen mode


### PR DESCRIPTION
runIn240p currently forces 4:3 mode, however SD widescreen CRTs exist (I own one). This code change respects the Wii's aspect ratio so that 240p mode and 16:9 can both be active. Tested on my own Wii and CRT.
![sonic-mania-240p-widescreen-v0-z7irjfo2iwfg1](https://github.com/user-attachments/assets/85ab1608-e9e5-47f9-b03e-c5ea30143944)
